### PR TITLE
Patch so tauri-driver is found on Windows by the test runner.

### DIFF
--- a/e2e/.gitattributes
+++ b/e2e/.gitattributes
@@ -1,0 +1,1 @@
+* text=auto

--- a/e2e/wdio.conf.js
+++ b/e2e/wdio.conf.js
@@ -3,6 +3,7 @@ import { spawn, spawnSync } from "child_process";
 import { CrabNebulaCloudReporter } from "@crabnebula/webdriverio-cloud-reporter";
 import { waitTauriDriverReady } from "@crabnebula/tauri-driver";
 import { fileURLToPath } from "url";
+import os from "os";
 
 const __dirname = fileURLToPath(new URL(".", import.meta.url));
 
@@ -79,9 +80,11 @@ export const config = {
   // ensure we are running `tauri-driver` before the session starts so that we can proxy the webdriver requests
   beforeSession: async () => {
     // tauriDriver = spawn(tauriDriverPath, [], {
-    tauriDriver = spawn("pnpm", ["tauri-driver"], {
-      stdio: [null, process.stdout, process.stderr],
-    });
+    tauriDriver = spawn(
+      path.resolve(os.homedir(), ".cargo", "bin", "tauri-driver"),
+      [],
+      { stdio: [null, process.stdout, process.stderr] }
+    );
     tauriDriver.on("error", (error) => {
       console.error("tauri-driver error:", error);
       process.exit(1);

--- a/e2e/wdio.conf.js
+++ b/e2e/wdio.conf.js
@@ -3,7 +3,6 @@ import { spawn, spawnSync } from "child_process";
 import { CrabNebulaCloudReporter } from "@crabnebula/webdriverio-cloud-reporter";
 import { waitTauriDriverReady } from "@crabnebula/tauri-driver";
 import { fileURLToPath } from "url";
-import os from "os";
 
 const __dirname = fileURLToPath(new URL(".", import.meta.url));
 
@@ -80,11 +79,10 @@ export const config = {
   // ensure we are running `tauri-driver` before the session starts so that we can proxy the webdriver requests
   beforeSession: async () => {
     // tauriDriver = spawn(tauriDriverPath, [], {
-    tauriDriver = spawn(
-      path.resolve(os.homedir(), ".cargo", "bin", "tauri-driver"),
-      [],
-      { stdio: [null, process.stdout, process.stderr] }
-    );
+    tauriDriver = spawn("pnpm", ["tauri-driver"], {
+      stdio: [null, process.stdout, process.stderr],
+      shell: true,
+    });
     tauriDriver.on("error", (error) => {
       console.error("tauri-driver error:", error);
       process.exit(1);


### PR DESCRIPTION
This code is based on:
   https://github.com/tauri-apps/webdriver-example

I kept the formatting from that code. Please LMK if there are any code formatting or lint checks etc to run before submitting PRs here.

I added .gitattributes to stop my windows instance from messing up line endings in the git diff. Thanks to:
https://www.aleksandrhovhannisyan.com/blog/crlf-vs-lf-normalizing-line-endings-in-git/